### PR TITLE
Add targetlabels for servicemonitor [stable/prometheus-redis-exporter]

### DIFF
--- a/stable/prometheus-redis-exporter/Chart.yaml
+++ b/stable/prometheus-redis-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.4
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 3.1.0
+version: 3.1.1
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/stable/prometheus-redis-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-redis-exporter/templates/servicemonitor.yaml
@@ -24,6 +24,13 @@ spec:
     scrapeTimeout: {{ .Values.serviceMonitor.timeout }}
 {{- end }}
   jobLabel: {{ template "prometheus-redis-exporter.fullname" . }}
+  targetLabels:
+{{ toYaml . | trim | indent 4 -}}
+  {{- end }}
+  {{- with .Values.serviceMonitor.podTargetLabels }}
+  podTargetLabels:
+{{ toYaml . | trim | indent 4 -}}
+  {{- end }}
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}

--- a/stable/prometheus-redis-exporter/values.yaml
+++ b/stable/prometheus-redis-exporter/values.yaml
@@ -49,8 +49,13 @@ serviceMonitor:
   # telemetryPath: /metrics
   # Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
   # labels:
+  # Import selected labels from service to prometheus
+  # targetLabels: []
+  # Import selected labels from pod to prometheus
+  # podTargetLabels: []
   # Set timeout for scrape
   # timeout: 10s
+
 
 # Used to mount a LUA-Script via config map and use it for metrics-collection
 # script:


### PR DESCRIPTION
Eventually going to merge this into helm/charts. Until then I'll use locally. 